### PR TITLE
use `https://` instead of `http://`

### DIFF
--- a/syntax/toml.vim
+++ b/syntax/toml.vim
@@ -1,6 +1,6 @@
 " Language:   TOML
 " Maintainer: Caleb Spare <cespare@gmail.com>
-" URL:        http://github.com/cespare/vim-toml
+" URL:        https://github.com/cespare/vim-toml
 " LICENSE:    MIT
 
 if exists("b:current_syntax")
@@ -35,7 +35,7 @@ hi def link tomlFloat Float
 syn match tomlBoolean /\<\%(true\|false\)\>/ display
 hi def link tomlBoolean Boolean
 
-" http://tools.ietf.org/html/rfc3339
+" https://tools.ietf.org/html/rfc3339
 syn match tomlDate /\d\{4\}-\d\{2\}-\d\{2\}T\d\{2\}:\d\{2\}:\d\{2\}\%(\.\d\+\)\?\%(Z\|[+-]\d\{2\}:\d\{2\}\)/ display
 hi def link tomlDate Constant
 


### PR DESCRIPTION
Both of the servers referenced in this file respond with content on HTTPS, and the GitHub HTTP link is a redirect to HTTPS.